### PR TITLE
[ci skip] Get more Open Source Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # bundle_requests
 
+[![Help Contribute to Open Source](https://www.codetriage.com/lprashant-94/bundle_requests/badges/users.svg)](https://www.codetriage.com/lprashant-94/bundle_requests)
 
 This is the middleware which will combine multiple request from different clients, bundle as single request and process once using batch processing API. This works for rails threaded server e.g. PUMA.
 
 ![ScreenShot](https://raw.github.com/lprashant-94/bundle_requests/master/HighLevelDesign.jpg)
 
 #### How it works.
-This gem is designed for situations wherein large numberof  network calls throtten at database. This gem is specifically useful in case of microrequests which complete in very small time. Using this you can accumulate multiple requests and process them in bulk. While processing it in bulk we get a chance to do optimizations in code and pipeline them in network calls. 
+This gem is designed for situations wherein large numberof  network calls throtten at database. This gem is specifically useful in case of microrequests which complete in very small time. Using this you can accumulate multiple requests and process them in bulk. While processing it in bulk we get a chance to do optimizations in code and pipeline them in network calls.
 
-Internal design of gem is based on Producer-Consumer model. This gem is only for multithreaded rails server. This provides you rack middleware which will run on top of your existing rails middleware stack. While initialising middleware it will automatically spawn consumer thread. 
-Now after receiving request on thread, each thread will push request into common Queue and will sleep. In this way, as time goes on it will accumulate multiple requests in Queue. 
+Internal design of gem is based on Producer-Consumer model. This gem is only for multithreaded rails server. This provides you rack middleware which will run on top of your existing rails middleware stack. While initialising middleware it will automatically spawn consumer thread.
+Now after receiving request on thread, each thread will push request into common Queue and will sleep. In this way, as time goes on it will accumulate multiple requests in Queue.
 Consumer will wake up after completing its sleep time and read all requests. Then it will create new request to bundle_api which is optimised and will send all the data in JSON same as below.
 ```
 {"requests" => [request1, request2]}
@@ -19,7 +20,7 @@ Now its duty of bundle_api to handle all these requests's content and respond ba
 {"response" : [[200,{"Content-Type" => "application/json"},["Status Ok"]], [200,{"Content-Type" => "application/json"},["Status Ok"]]   ]}
 ```
 
-Once consumer gets all these responses, it will distribute those responses back to each thread and will wake them up. 
+Once consumer gets all these responses, it will distribute those responses back to each thread and will wake them up.
 Once threads wake up they respond client with correct response, and start waiting for next request.
 Consumer will first check if number of waiting requests are outnumbered max_waiting_thread otherwise it will sleep for wait_time and process new requests. In this way cycle goes on.
 
@@ -42,7 +43,7 @@ config.middleware.insert_before 0, BundleRequests::RackMiddleware, {
 
 *Important note is Benchmark your configurations for best results*
 
-#### TASKLIST 
+#### TASKLIST
 - [x] Update readme correctly - Use code block and all
 - [x] Use thread stop and wakeup and remove locks
 - [ ] Test current gem on sample project
@@ -53,7 +54,7 @@ config.middleware.insert_before 0, BundleRequests::RackMiddleware, {
 - [x] Switch to Producer-Consumer model, shift all master code to producer and consumer will just wait for producers signal
 - [x] Use Thread local variable for results and remove instance variable. Minimize instance variables
 - [ ] Use Thread pool for consumers
-- [ ] Support for multiple api's 
+- [ ] Support for multiple api's
 - [x] Have Maximum number of waiting threads, to bypass sleep call
 
 
@@ -68,5 +69,5 @@ config.middleware.insert_before 0, BundleRequests::RackMiddleware, {
 - Headers are not passed to request handler
 - Supports only post requests (Currently.)
 - All clients need to wait for some time (User can do middleware configuration in such a way that it wont affect user experience and run with maximal capacity. Keeping wait_time less than 10-20ms also works great.)
-- Need to write new bundle api 
+- Need to write new bundle api
 


### PR DESCRIPTION
[CodeTriage](https://www.codetriage.com/) is an app I have maintained
for the past 4-5 years with the goal of getting people involved in
Open Source projects like this one. The app sends subscribers a random
open issue for them to help "triage". For some languages you can also
suggested areas to add documentation.

The initial approach was inspired by seeing the work of the small
core team spending countless hours asking "what version was
this in" and "can you give us an example app". The idea is to
outsource these small interactions to a huge team of volunteers
and let the core team focus on their work.

I want to add a badge to the README of this project. The idea is to
provide an easy link for people to get started contributing to this
project. A badge indicates the number of people currently subscribed
to help the repo. The color is based off of open issues in the project.

Here are some examples of other projects that have a badge in their
README:

- https://github.com/crystal-lang/crystal
- https://github.com/rails/rails
- https://github.com/codetriage/codetriage

Thanks for building open source software, I would love to help you find some helpers.